### PR TITLE
CBD TRaining Renovation 2025

### DIFF
--- a/2-env-setup/k8s/01-namespace.yaml
+++ b/2-env-setup/k8s/01-namespace.yaml
@@ -1,0 +1,7 @@
+#   create the "sample" namespace where the k8s-sample application will live
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: sample
+    labels:
+        name: sample

--- a/2-env-setup/k8s/02-namespace-admin.yaml
+++ b/2-env-setup/k8s/02-namespace-admin.yaml
@@ -1,0 +1,38 @@
+#   create "sample" service account in "sample" namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    namespace: sample
+    name: sample
+    labels:
+        name: sample
+---
+#   create full-access role for service account "sample" in "sample" namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    namespace: sample
+    name: sample-role
+    labels:
+        name: sample
+rules:
+    -   apiGroups: [ "", "*" ]
+        resources: [ "*" ]
+        verbs: [ "*" ]
+---
+#   bind full-access role to service account "sample" in "sample" namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    namespace: sample
+    name: sample-role-binding
+    labels:
+        name: sample
+subjects:
+    -   kind: ServiceAccount
+        namespace: sample
+        name: sample
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: sample-role

--- a/2-env-setup/k8s/03-secret.yaml
+++ b/2-env-setup/k8s/03-secret.yaml
@@ -1,0 +1,9 @@
+#   create a secret (an authentication token) for the "sample" service account
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sample-token
+  namespace: sample
+  annotations:
+    kubernetes.io/service-account.name: sample
+type: kubernetes.io/service-account-token

--- a/2-env-setup/k8s/README.md
+++ b/2-env-setup/k8s/README.md
@@ -1,0 +1,8 @@
+These YAML files are used to bootstrap the K8s environment needed to
+run the k8s-sample application. They
+- create the namespace
+- create the service account for this namespace
+- create a secret for this service account so that kubectl can authenticate
+
+The YAML files have to be applied (using `kubectl apply`) in the order given
+by their filename.

--- a/4-app-container/Dockerfile
+++ b/4-app-container/Dockerfile
@@ -13,7 +13,7 @@ ARG         IMAGE_RELEASE=20200612
 #   ==== STAGE 1 ====
 
 #   derive image from a certain base image
-FROM        golang:1.23.1-alpine3.19 AS stage1
+FROM        golang:1.24-alpine3.22 AS stage1
 
 #   add additional build tools
 RUN         apk update && apk upgrade && apk add git binutils
@@ -34,14 +34,14 @@ RUN         strip dockerize
 #   ==== STAGE 2 ====
 
 #   start with the standard Node.js container image
-FROM        node:12.18-alpine AS stage2
+FROM        node:24-alpine AS stage2
 
 #   update system
 RUN         apk update && apk upgrade && apk add bash
 
 #   provide build environment
 RUN         apk add --no-cache --virtual .build-env \
-                binutils-gold gcc g++ python make shadow xz tar \
+                binutils-gold gcc g++ python3 make shadow xz tar \
                 libc-dev linux-headers libgcc libstdc++
 
 #   create application program area
@@ -62,12 +62,12 @@ RUN         (echo "spin=false"; echo "save=false"; echo "loglevel=error") >/app/
 
 #   build application
 RUN         (cd fe && npm install --silent && NODE_ENV=production npm run build)
-RUN         (cd be && npm install --silent --production)
+RUN         (cd be && npm install --silent --production -y)
 
 #   ==== STAGE 3 ====
 
 #   start with the standard Node.js container image
-FROM        node:12.18-alpine
+FROM        node:24-alpine AS stage3
 
 #   update system
 RUN         apk update && apk upgrade && apk add bash

--- a/5-run-docker/Composefile.pgsql
+++ b/5-run-docker/Composefile.pgsql
@@ -4,8 +4,6 @@
 ##  Distributed under MIT license <https://spdx.org/licenses/MIT.html>
 ##
 
-version: "3.7"
-
 services:
 
     #   the k8s-sample application

--- a/5-run-docker/Composefile.sqlite
+++ b/5-run-docker/Composefile.sqlite
@@ -4,8 +4,6 @@
 ##  Distributed under MIT license <https://spdx.org/licenses/MIT.html>
 ##
 
-version: "3.7"
-
 services:
 
     #   the k8s-sample application

--- a/6-run-kubernetes/templates/1-app.yaml
+++ b/6-run-kubernetes/templates/1-app.yaml
@@ -158,7 +158,8 @@ spec:
 
 ---
 {{- if .Values.app.storage.shared }}
-#   persistent volume claim
+#   persistent volume claim, needed for "shared DB. The (only) volume prepared 
+#   by this PVC is then used by all pods.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/6-run-kubernetes/templates/1-app.yaml
+++ b/6-run-kubernetes/templates/1-app.yaml
@@ -7,16 +7,6 @@
 
 ---
 {{- if .Values.app.service.url }}
-#   traefik path prefix stripping
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-    name: path-prefix
-spec:
-    stripPrefix:
-        prefixes:
-            - {{ default "/" .Values.app.service.url }}
----
 #   traffic ingress for service
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -27,7 +17,7 @@ metadata:
         pkg: {{ template "package.fullname" . }}
         tier: {{ .Values.app.name }}
     annotations:
-        traefik.ingress.kubernetes.io/router.middlewares: {{ template "package.namespace" . }}-path-prefix@kubernetescrd
+        nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
     rules:
         {{- if .Values.app.service.host }}
@@ -37,8 +27,8 @@ spec:
         -   http:
         {{- end }}
                 paths:
-                    -   pathType: Prefix
-                        path: {{ default "/" .Values.app.service.url }}
+                    -   pathType: ImplementationSpecific
+                        path: {{ default "/" .Values.app.service.url }}/?(.*)
                         backend:
                             service:
                                 name: {{ template "package.fullname" . }}-{{ .Values.app.name }}

--- a/6-run-kubernetes/values.yaml
+++ b/6-run-kubernetes/values.yaml
@@ -34,8 +34,8 @@ app:
         url:          /k8s-sample
     storage:
         path:         /data
-        mode:         Filesystem
-        type:         null
+        mode:         null
+        type:         csi-hostpath-sc
         size:         100Mi
         gid:          null
         shared:       false

--- a/6-run-kubernetes/values.yaml
+++ b/6-run-kubernetes/values.yaml
@@ -61,7 +61,7 @@ db:
         port:         5432
     storage:
         path:         /data
-        type:         nfs
+        type:         csi-hostpath-sc
         size:         100Mi
         gid:          null
         shared:       false


### PR DESCRIPTION
See separate Mail.

- Wechsel des CSI-Providers von nfs auf csi-hostpath-sc

- Wechsel des Ingress-Providers von traefik auf nginx

- Upgrade der Base-Images: golang:1.23.1-alpine3.19 auf 1.24-alpine3.22; node 12.18 auf node 24 (benötigte auch punktuelle Anpassungen in den RUN Kommandos aufgrund Änderungen bei den Tools/Debian Packages)

- Verzicht auf k8s-util und kubensx. Beide sind nützlich, aber für eine Grundlagenschulung hat diese Verschattung immer wieder Unklarheiten und Irritationen ausgelöst. Jetzt sehen die Teilnehmer auch hier, wie es „ganz unten“ aussieht und wie sie rein mit Bordmitteln weiterkommen (Account/Role/Secret Erzeugung über explizite YAML-Files, ContextSwitch über `kubectl –use-context`). Dazu Hinzufügen von drei YAML-Dateien im neuen Verzeichnis 2-env-setup/k8s (für K8s Namespace, Namespace-Admin-Account und Secret Generierung). Die restlichen Dateien in 2-env-setup werden in der Schulung nicht (mehr) genutzt, sind aber noch im Repo.